### PR TITLE
Modifica el dockerfile para cambiar el puerto y agregar migraciones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copia el resto del código fuente de la aplicación al contenedor
 COPY . .
 
+# Ejecutar migraciones (solo por usar sqlite como base de datos)
+RUN python manage.py migrate
+
 # Expone el puerto 8000 (por defecto para Django)
 EXPOSE 8000
 
-# Comando por defecto: inicia el servidor de desarrollo de Django
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+# Comando por defecto para iniciar la app con Gunicorn
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "eventhub.wsgi:application"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ typing_extensions==4.13.2
 tzdata==2025.2
 urllib3==2.4.0
 python-dotenv
+gunicorn


### PR DESCRIPTION
En esta pr se corrije el error de no ejecutar el comando migrate cuando se realiza el deploy en Render,  actualizando el dockerfile agregando el comando migrate (esto es solo por usar Sqlite).  Además se cambia el puerto para levantar la aplicación de runserver a Gunicorn.