### PR TITLE
Habilita deploy continuo al mergear en main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,9 @@
 name: Continuous Delivery
 
 on:
+  push:
+    branches:
+      - main
   release:
     types: [published]
   workflow_run:
@@ -9,11 +12,15 @@ on:
     types:
       - completed
 
+
 jobs:
   cd:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'release' }}
-    
+    if: >
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'push'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Se actualizó el archivo cd.yml para permitir el despliegue automático de la aplicación cuando se realiza un merge hacia la rama main.
Se modificó la condición del job de CD para incluir push a main además de releases y ejecución exitosa del workflow de CI.

Esta mejora permite que la entrega continua se realice no solo en releases, sino también directamente al integrar PRs en main.

