### PR TITLE
Agrega dominio de Render a la variable del settings ALLOWED_HOSTS

### DIFF
--- a/eventhub/settings.py
+++ b/eventhub/settings.py
@@ -30,7 +30,7 @@ SECRET_KEY = os.getenv("SECRET_KEY", "django-insecure--f67ll=2-b2qolla9=1f8mtg@s
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", "False") == "True"
 
-ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
+ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1,eventhub-643h.onrender.com").split(",")
 
 CSRF_TRUSTED_ORIGINS = ["https://eventhub-643h.onrender.com",]
 


### PR DESCRIPTION
Esta PR es para solucionar el error de CSRF que da cuando se hace el deploy en Render. Se harcodeo el dominio de Render en la variable del settings.py ALLOWED_HOSTS.