### PR TITLE
Elimina la condicion de tagear como latest simpre que solo se haga una release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest
             type=sha,format=short,prefix=,enable=${{ github.event_name != 'release' }}
 
       - name: Build and push Docker image

--- a/eventhub/settings.py
+++ b/eventhub/settings.py
@@ -30,9 +30,7 @@ SECRET_KEY = os.getenv("SECRET_KEY", "django-insecure--f67ll=2-b2qolla9=1f8mtg@s
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", "False") == "True"
 
-ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1,eventhub-643h.onrender.com").split(",")
-
-CSRF_TRUSTED_ORIGINS = ["https://eventhub-643h.onrender.com",]
+ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
 
 # Application definition
 


### PR DESCRIPTION
Este PR realiza los siguientes cambios:

1) **Eliminación de la condición para el tag latest en el workflow de CD**:
    - Antes, la imagen Docker solo se taggeaba como latest al generar una release (`github.event_name == 'release'`).
    - Ahora, se aplica el tag latest tanto en releases como en merges a la rama main, asegurando que siempre haya una imagen  latest actualizada con los cambios más recientes en producción.

 2) **Eliminación de URLs hardcodeadas de Render en settings.py**:
    - Se eliminaron las URLs de Render que estaban fijas en el archivo settings.py y no eran necesarias.
    - Esto mejora la mantenibilidad del código y evita dependencias innecesarias de entorno.